### PR TITLE
github-comment: fix module format

### DIFF
--- a/github-comment/github.go
+++ b/github-comment/github.go
@@ -21,7 +21,7 @@ func New(
 	ctx context.Context,
 	githubToken *Secret,
 	// +optional
-	// +default=github.com/aluzzardi/daggerverse/github-comment
+	// +default="github.com/aluzzardi/daggerverse/github-comment"
 	messageID string,
 	owner string,
 	repo string,


### PR DESCRIPTION
Updates default argument to new format. So the module can be used with latest dagger.